### PR TITLE
Fix errors & warnings on Linux GCC 4.9

### DIFF
--- a/src/expr.h
+++ b/src/expr.h
@@ -34,7 +34,7 @@ static int vec_expand(char **buf, int *length, int *cap, int memsz) {
 #define vec_unpack(v)                                                          \
   (char **)&(v)->buf, &(v)->len, &(v)->cap, sizeof(*(v)->buf)
 #define vec_push(v, val)                                                       \
-  (vec_expand(vec_unpack(v)) ? -1 : ((v)->buf[(v)->len++] = (val), 0), 0)
+  vec_expand(vec_unpack(v)) ? -1 : ((v)->buf[(v)->len++] = (val), 0)
 #define vec_nth(v, i) (v)->buf[i]
 #define vec_peek(v) (v)->buf[(v)->len - 1]
 #define vec_pop(v) (v)->buf[--(v)->len]

--- a/src/glitch.c
+++ b/src/glitch.c
@@ -683,7 +683,7 @@ static float lib_pluck(struct expr_func *f, vec_expr_t args, void *context) {
   }
 
   int n = SAMPLE_RATE / freq;
-  if (isnan(n) || n == 0) {
+  if (n == 0) {
     return NAN;
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -217,7 +217,7 @@ int main(int argc, char *argv[]) {
   int opt;
   struct glitch *g = NULL;
   char *device = NULL;
-  char *midi = NULL;
+  const char *midi = NULL;
   unsigned int bufsz = 512;
 
   int sample_rate = 48000;


### PR DESCRIPTION
Some minor fixes - commit messages self-explanatory.